### PR TITLE
Remove unused global variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@ import pyaudio
 global mic_stream
 global ser
 global comport
-global start
 global tot_timer
 
 on_air = False


### PR DESCRIPTION
## Summary
- delete unused `global start` declaration

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68418e35adf88321bf24d7b1043313f3