### PR TITLE
Fix PyInstaller paths

### DIFF
--- a/PTT.spec
+++ b/PTT.spec
@@ -1,13 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+project_root = os.path.abspath(SPECPATH)
+
 
 block_cipher = None
 
 
-a = Analysis(['C:/Users/werner/PycharmProjects/ptt/main.py'],
-             pathex=['C:\\Users\\werner\\PycharmProjects\\ptt'],
+a = Analysis([os.path.join(project_root, 'main.py')],
+             pathex=[project_root],
              binaries=[],
-             datas=[('C:/Users/werner/PycharmProjects/ptt/pics/ptt.png', '/pics')],
+             datas=[(os.path.join(project_root, 'pics', 'ptt.png'), 'pics')],
              hiddenimports=[],
              hookspath=[],
              runtime_hooks=[],
@@ -31,4 +35,4 @@ exe = EXE(pyz,
           upx=True,
           upx_exclude=[],
           runtime_tmpdir=None,
-          console=False , icon='C:\\Users\\werner\\PycharmProjects\\ptt\\pics\\ptt.ico')
+         console=False , icon=os.path.join(project_root, 'pics', 'ptt.ico'))

--- a/make.bat
+++ b/make.bat
@@ -1,1 +1,3 @@
-pyinstaller --noconfirm --onefile --windowed --icon "C:/Users/werner/PycharmProjects/ptt/pics/ptt.ico" --name "PTT" --add-data "C:/Users/werner/PycharmProjects/ptt/pics/ptt.png;/pics"  "C:/Users/werner/PycharmProjects/ptt/main.py"
+@echo off
+set "ROOT=%~dp0"
+pyinstaller --noconfirm --onefile --windowed --icon "%ROOT%pics\ptt.ico" --name "PTT" --add-data "%ROOT%pics\ptt.png;pics" "%ROOT%main.py"


### PR DESCRIPTION
## Summary
- update `PTT.spec` to compute resource paths based on the spec location
- make the Windows build script use `%~dp0` for relative paths

## Testing
- `python -m py_compile main.py`
- `pyinstaller --log-level WARN PTT.spec`

------
https://chatgpt.com/codex/tasks/task_e_68418e3a3e148321a0845c944df125a8