### PR TITLE
Fix song title using basename

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from time import sleep
 from tkinter import *
 from tkinter import filedialog
 from tkinter import ttk
+import os
 
 import pygame
 import pygame._sdl2 as sdl2
@@ -224,8 +225,7 @@ def open_song():
     global song_title
     filename = filedialog.askopenfilename(initialdir="C:/", title="Bitte MP3-Datei auswählen")
     current_song = filename
-    song_title = filename.split("/")
-    song_title = song_title[-1]
+    song_title = os.path.basename(filename)
 
 
 def volume(x):


### PR DESCRIPTION
## Summary
- import `os`
- use `os.path.basename` when selecting MP3 file in `open_song`

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68418e3ecf78832186c86ce87b6f0653