### PR TITLE
Fix serial cleanup when COM port unused

### DIFF
--- a/main.py
+++ b/main.py
@@ -340,8 +340,9 @@ aufnahme_combo.bind("<<ComboboxSelected>>", aufnahme_select)
 
 root.mainloop()
 on_air = False
-ser.setRTS(False)
-ser.setDTR(False)
-ser.close()
+if 'ser' in globals() and ser:
+    ser.setRTS(False)
+    ser.setDTR(False)
+    ser.close()
 stop()
 mixer.stop()


### PR DESCRIPTION
## Summary
- wrap serial cleanup after `root.mainloop()` in conditional check

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68418e41b2608321bbaced7d2baf90d1