### PR TITLE
Fix duplicate timeout thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,7 @@ label2.grid(row=0, column=1, columnspan=4)
 
 current_volume = float(0.5)
 tot_timer = 0
+tot_thread = None
 
 # COM-Ports aus dem System auslesen und in das Dropdown-Menü einbinden.
 OptionList = []
@@ -208,15 +209,16 @@ def tx():
 
 
 def senden():
-    global on_air
+    global on_air, tot_thread
     on_air = True
     ser.setRTS(True)
     ser.setDTR(True)
     tx_button.config(state=DISABLED)
     rx_button.config(state=ACTIVE)
     status.config(text=f"TX auf {comport}")
-    if tot_timer != 0:
-        threading.Thread(target=tot, args=(tot_timer,), daemon=True).start()
+    if tot_timer != 0 and (tot_thread is None or not tot_thread.is_alive()):
+        tot_thread = threading.Thread(target=tot, args=(tot_timer,), daemon=True)
+        tot_thread.start()
 
 
 def nicht_senden():
@@ -231,7 +233,7 @@ def nicht_senden():
 
 
 def com_schliessen():
-    global on_air
+    global on_air, tot_thread
     on_air = False
     rx_button.config(state=DISABLED)
     tx_button.config(state=DISABLED)
@@ -242,6 +244,8 @@ def com_schliessen():
     ser.setRTS(False)
     ser.setDTR(False)
     ser.close()
+    if tot_thread is not None:
+        tot_thread.join(timeout=0.1)
     stop()
 
 

--- a/main.py
+++ b/main.py
@@ -205,9 +205,6 @@ def tx():
     on_air = True
     t1 = threading.Thread(target=senden)
     t1.start()
-    if tot_timer != 0:
-        tot1 = threading.Thread(target=tot, args=(tot_timer,))
-        tot1.start()
 
 
 def senden():
@@ -219,7 +216,7 @@ def senden():
     rx_button.config(state=ACTIVE)
     status.config(text=f"TX auf {comport}")
     if tot_timer != 0:
-        threading.Thread(target=tot, args=(tot_timer,)).start()
+        threading.Thread(target=tot, args=(tot_timer,), daemon=True).start()
 
 
 def nicht_senden():


### PR DESCRIPTION
## Summary
- start the timeout thread once in `senden()`
- run the timeout thread as a daemon to avoid blocking exit

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841be394488832190306ff3b012289b