### PR TITLE
Fix default file selection dir

### DIFF
--- a/main.py
+++ b/main.py
@@ -255,7 +255,7 @@ status.grid(row=10, column=0, columnspan=5, sticky=W + E)
 def open_song():
     global current_song
     global song_title
-    filename = filedialog.askopenfilename(initialdir="C:/", title="Bitte MP3-Datei auswählen")
+    filename = filedialog.askopenfilename(initialdir=os.getcwd(), title="Bitte MP3-Datei auswählen")
     current_song = filename
     song_title = os.path.basename(filename)
 


### PR DESCRIPTION
## Summary
- improve cross-platform behavior for open_song by using the current directory

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841be4eada0832184375addde66535f