### PR TITLE
Release PyAudio handles after device scan

### DIFF
--- a/main.py
+++ b/main.py
@@ -169,6 +169,7 @@ def wiedergabe_select(e):
             if info.get('maxOutputChannels') and play_device in info.get('name', ''):
                 play_device_index = i
                 break
+        p.terminate()
     except Exception:
         play_device_index = None
 
@@ -184,6 +185,7 @@ def aufnahme_select(e):
             if info.get('maxInputChannels') and rec_device in info.get('name', ''):
                 rec_device_index = i
                 break
+        p.terminate()
     except Exception:
         rec_device_index = None
 


### PR DESCRIPTION
## Summary
- close PyAudio when enumerating devices for playback and recording

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841be541798832186507ee35bb2ee3e