### PR TITLE
Fix duplicate timeout thread

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,6 +40,8 @@ label2.grid(row=0, column=1, columnspan=4)
 
 current_volume = float(0.5)
 tot_timer = 0
+tot_thread = None
+tot_stop_event = threading.Event()
 
 # COM-Ports aus dem System auslesen und in das Dropdown-Menü einbinden.
 OptionList = []
@@ -132,11 +134,12 @@ def mic_off():
     mic_button.config(text="MIC ON", command=mic_on)
 
 
-def tot(tot_timer):
-    while on_air and tot_timer != 0:
+def tot(stop_event):
+    while on_air and tot_timer != 0 and not stop_event.is_set():
         print(f"Schlafe {tot_timer} Minute(n)...")
         timer = int(tot_timer) * 60 -2
-        sleep(timer)
+        if stop_event.wait(timer):
+            break
         mixer.music.pause()
         ser.setRTS(False)
         ser.setDTR(False)
@@ -150,7 +153,8 @@ def tot(tot_timer):
 
 def tot_auswahl(e):
     global tot_timer
-    tot_timer = tot_combo.get()
+    # store TOT timer as integer for proper comparisons
+    tot_timer = int(tot_combo.get())
 
 
 def wiedergabe_select(e):
@@ -205,21 +209,20 @@ def tx():
     on_air = True
     t1 = threading.Thread(target=senden)
     t1.start()
-    if tot_timer != 0:
-        tot1 = threading.Thread(target=tot, args=(tot_timer,))
-        tot1.start()
 
 
 def senden():
-    global on_air
+    global on_air, tot_thread
     on_air = True
     ser.setRTS(True)
     ser.setDTR(True)
     tx_button.config(state=DISABLED)
     rx_button.config(state=ACTIVE)
     status.config(text=f"TX auf {comport}")
-    if tot_timer != 0:
-        threading.Thread(target=tot, args=(tot_timer,)).start()
+    if tot_timer != 0 and (tot_thread is None or not tot_thread.is_alive()):
+        tot_stop_event.clear()
+        tot_thread = threading.Thread(target=tot, args=(tot_stop_event,), daemon=True)
+        tot_thread.start()
 
 
 def nicht_senden():
@@ -234,7 +237,7 @@ def nicht_senden():
 
 
 def com_schliessen():
-    global on_air
+    global on_air, tot_thread
     on_air = False
     rx_button.config(state=DISABLED)
     tx_button.config(state=DISABLED)
@@ -245,6 +248,10 @@ def com_schliessen():
     ser.setRTS(False)
     ser.setDTR(False)
     ser.close()
+    if tot_thread is not None:
+        tot_stop_event.set()
+        tot_thread.join(timeout=0.1)
+        tot_thread = None
     stop()
 
 


### PR DESCRIPTION
## Summary
- start the timeout thread once in `senden()`
- run the timeout thread as a daemon to avoid blocking exit
- clean up the thread with an Event so it stops immediately

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841be394488832190306ff3b012289b